### PR TITLE
Fix description for inputs.coverage

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,9 @@ inputs:
     description: 'Test directory'
     default: 'tests'
   coverage:
-    description: 'Flags for code coverage'
+    description: |
+      Check coverage with Codecov
+      Default is true.
     default: true
   flags:
     description: 'Flags for code coverage'


### PR DESCRIPTION
This rewrites the description for the `coverage` value in the `inputs` map, to clarify what it actually does (enable/disable checking code coverage via codecov).